### PR TITLE
Modify aserto dependency in flask-aserto

### DIFF
--- a/packages/flask-aserto/pyproject.toml
+++ b/packages/flask-aserto/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flask-aserto"
-version = "0.20.0"
+version = "0.20.1"
 description = "Aserto integration for Flask"
 readme = "README.md"
 authors = ["Aserto, Inc. <pypi@aserto.com>"]

--- a/packages/flask-aserto/pyproject.toml
+++ b/packages/flask-aserto/pyproject.toml
@@ -33,7 +33,7 @@ Flask = {version = "^2.0.1", extras = ["async"]}
 Flask-Cors = "^3.0.10"
 grpcio = "^1.49.1"
 protobuf = "^4.21.7"
-aserto = "^0.20.0"
+aserto = "~= 0.20"
 
 [tool.poetry.dev-dependencies]
 black = "21.7b0"

--- a/packages/flask-aserto/pyproject.toml
+++ b/packages/flask-aserto/pyproject.toml
@@ -33,7 +33,7 @@ Flask = {version = "^2.0.1", extras = ["async"]}
 Flask-Cors = "^3.0.10"
 grpcio = "^1.49.1"
 protobuf = "^4.21.7"
-aserto = "~= 0.20"
+aserto = ">= 0.20"
 
 [tool.poetry.dev-dependencies]
 black = "21.7b0"


### PR DESCRIPTION
This PR relaxes the version constraint that flask-aserto has on the aserto package.
Instead of `^0.20.0` which matches only `0.20.*` versions, we now use `>= 0.20` which accepts all `0.x.*` where `x >= 20`.