### PR TITLE
Update async directory client to match sync

### DIFF
--- a/src/aserto/client/directory/v3/aio/__init__.py
+++ b/src/aserto/client/directory/v3/aio/__init__.py
@@ -405,38 +405,41 @@ class Directory:
     @typing.overload
     async def get_relation(
         self,
+        *,
+        with_objects: typing.Literal[False] = False,
         object_type: str = "",
         object_id: str = "",
         relation: str = "",
         subject_type: str = "",
         subject_id: str = "",
         subject_relation: str = "",
-        with_objects: typing.Literal[False] = False,
     ) -> Relation:
         ...
 
     @typing.overload
     async def get_relation(
         self,
+        *,
+        with_objects: typing.Literal[True],
         object_type: str = "",
         object_id: str = "",
         relation: str = "",
         subject_type: str = "",
         subject_id: str = "",
         subject_relation: str = "",
-        with_objects: typing.Literal[True] = True,
     ) -> RelationResponse:
         ...
 
     async def get_relation(
         self,
+        *,
+        with_objects: bool = False,
         object_type: str = "",
         object_id: str = "",
         relation: str = "",
         subject_type: str = "",
         subject_id: str = "",
         subject_relation: str = "",
-        with_objects: bool = False,
     ) -> typing.Union[Relation, RelationResponse]:
         """Retrieve a directory relation that matches the specified filters.
         Raises a NotFoundError no matching relation is found.

--- a/test/test_directory_v3_async.py
+++ b/test/test_directory_v3_async.py
@@ -184,7 +184,12 @@ async def test_delete_object(directory: Directory):
 
     # Relations should remain intact
     rel = await directory.get_relation(
-        "user", "morty@the-citadel.com", "manager", "user", "rick@the-citadel"
+        with_objects=False,
+        object_type="user",
+        object_id="morty@the-citadel.com",
+        relation="manager",
+        subject_type="user",
+        subject_id="rick@the-citadel.com",
     )
     assert rel is not None
     assert rel.object_type == "user"


### PR DESCRIPTION
https://github.com/aserto-dev/aserto-python/pull/30 changed the signature of `Directory.get_relation()`.
This PR makes the same change to the async directory client.